### PR TITLE
Issue #3

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -72,13 +72,6 @@ func getCLIArgs() (config ARGS, boards []string) {
 		os.Exit(0)
 	}
 
-	// Check for required flag of Board ID
-	/*if *BoardID == "" {
-		fmt.Println("Error: No Board ID provided. REQUIRED")
-		printHelp(version)
-		os.Exit(1)
-	} */
-
 	// If no board ID is provided, check if stdin is piped
 	boards, err := getBoardIDs(*BoardID, os.Stdin)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func main() {
 
-	version = "0.2.00"
+	version = "0.2.01"
 
 	// Load CLI arguments and OS ENV
 	// This also must handle stin Pipe input
@@ -60,7 +60,7 @@ func main() {
 			fmt.Printf("\n\nLabel IDs for Board: %s (%s)\n\n", board.Name, board.ID)
 			prettyPrintLabels(labels, false)
 
-			os.Exit(0)
+			continue
 		}
 
 		/* Process Card Counts Request */
@@ -87,17 +87,22 @@ func main() {
 			t.Render()
 
 			fmt.Println()
-			os.Exit(0)
+
+			continue
 		}
 
 		/* Process board data */
-		fmt.Println()
-		fmt.Println("Processing Board Name:", board.Name)
-		dumpABoard(config, board, client)
+		if !config.ARGS.ListLabelIDs && !config.ARGS.ListTotalCards {
+			fmt.Println()
+			fmt.Println("Processing Board Name:", board.Name)
+			dumpABoard(config, board, client)
 
-		fmt.Println()
-		fmt.Println("Processing Complete")
+			fmt.Println()
+			fmt.Println("Processing Complete")
+		}
 	}
 
-	fmt.Println("Your board backups are in the directory:", config.ARGS.StoragePath)
+	if !config.ARGS.ListLabelIDs && !config.ARGS.ListTotalCards {
+		fmt.Println("Your board backups are in the directory:", config.ARGS.StoragePath)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func main() {
 
-	version = "0.2.01"
+	version = "0.2.02"
 
 	// Load CLI arguments and OS ENV
 	// This also must handle stin Pipe input
@@ -34,6 +34,11 @@ func main() {
 
 	// Create Trello Client
 	client = trello.NewClient(config.ENV.TRELLOAPIKEY, config.ENV.TRELLOAPITOK)
+
+	// Message this once outside the loop, rather than for each board on multiple board input
+	if config.ARGS.ListTotalCards {
+		fmt.Printf("\n\nLarge Boards will take a moment to retreive this data...\n\n")
+	}
 
 	// Range through board IDs.  Came in via CLI args or stdin pipe
 	for _, boardID := range listOfBoards {
@@ -66,7 +71,6 @@ func main() {
 		/* Process Card Counts Request */
 		if config.ARGS.ListTotalCards {
 
-			fmt.Printf("\n\nLarge Boards will take a moment to retreive this data...\n\n")
 			totalCards, _ := board.GetCards(trello.Arguments{"filter": "all"})
 			openCards, _ := board.GetCards(trello.Arguments{"filter": "open"})
 			closedCards, _ := board.GetCards(trello.Arguments{"filter": "closed"})
@@ -84,6 +88,9 @@ func main() {
 
 			t.SetStyle(table.StyleLight)
 			t.Style().Color.Header = text.Colors{text.FgHiGreen, text.Bold}
+
+			fmt.Printf("\n\nCard Counts for Board: %s (%s)\n\n", board.Name, board.ID)
+
 			t.Render()
 
 			fmt.Println()

--- a/trello.go
+++ b/trello.go
@@ -64,7 +64,7 @@ func dumpABoard(config Config, board *trello.Board, client *trello.Client) {
 	}
 	labels, err := board.GetLabels(trello.Defaults())
 	if err != nil {
-		fmt.Println("Error: Unable to get label data for board ID "+board.ID+" ("+board.Name+")", config.ARGS.BoardID)
+		fmt.Println("Error: Unable to get label data for board ID "+board.ID+" ("+board.Name+")", board.ID)
 	} else {
 
 		buf := prettyPrintLabels(labels, true)
@@ -122,7 +122,7 @@ func dumpABoard(config Config, board *trello.Board, client *trello.Client) {
 		}
 		cards, err = client.SearchCards(query, trello.Defaults())
 		if err != nil {
-			fmt.Println("Error: Unable to get card data for board ID", config.ARGS.BoardID, "with label ID", config.ARGS.LabelID)
+			fmt.Println("Error: Unable to get card data for board ID", board.ID, "with label ID", config.ARGS.LabelID)
 			os.Exit(1)
 		}
 	} else {
@@ -133,7 +133,7 @@ func dumpABoard(config Config, board *trello.Board, client *trello.Client) {
 			cards, err = board.GetCards(trello.Arguments{"filter": "open"})
 		}
 		if err != nil {
-			fmt.Println("Error: Unable to get card data for board ID", config.ARGS.BoardID)
+			fmt.Println("Error: Unable to get card data for board ID", board.ID)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
This changes this up a bit, to allow for a list of board short ID's to be PIPED ( `|` ) into the binary and executed on in order.  Rather then specifying a single board ID via the `-b` current method.

Both methods are supported and `-b` is ignored if there's data coming in via STDIN pipe.

This will work with the `-labels` and `-count` parameters as well.

