### PR TITLE
Silent mode

### DIFF
--- a/feature.md
+++ b/feature.md
@@ -8,7 +8,7 @@
 # Board Stuff  
 - [x] Board members
 - [x] Add ability to filter board dump by specific LABELs
-- [ ] Add ability to feed a "list" of board ID's in and have it grab them all
+- [x] Add ability to feed a "list" of board ID's in and have it grab them all
 
 # Card Stuff  
 - [x] Card Covers 

--- a/functions.go
+++ b/functions.go
@@ -186,7 +186,7 @@ func printHelp(version string) {
 	fmt.Printf("  -count\tList total number of cards in the board\n")
 	fmt.Printf("  -l\t\tOnly include cards with this label NAME (Does not work with -a flag. Requires NAME of label \"in quotes\", not ID)\n")
 	fmt.Printf("  -labels\tRetrieve boards list of Label IDs\n")
-	fmt.Printf("  -loud\tEnable more verbose output\n")
+	fmt.Printf("  -loud\t\tEnable more verbose output\n")
 	fmt.Printf("  -qq\t\tSuppress ALL console output.  Super Quiet mode.  Does not effect logging, just console.  Does not apply to -labels or -count\n")
 	fmt.Printf("  -s\t\tRoot Level path to store board information (REQUIRED)\n")
 	fmt.Printf("  -split\tSeparate archived cards into their own directory (instead of mixed in and labeled with -ARCHIVED)\n")

--- a/functions.go
+++ b/functions.go
@@ -35,20 +35,24 @@ type ENV struct {
 	TRELLOAPIURL string
 }
 
-// getCLIArgs - Get CLI arguments and flags
+/*
+getCLIArgs
+
+	Get CLI arguments and flags
+*/
 func getCLIArgs() (config ARGS, boards []string) {
 
 	var (
 		// CLI Flags
-		Archived         = flag.Bool("a", false, "Include archived cards in dump")
-		BoardID          = flag.String("b", "", "Trello board to dump Unique Identifier (or PIPE (|) IDs in one per line)")
-		ListTotalCards   = flag.Bool("count", false, "List total number of cards in the board")
-		LabelID          = flag.String("l", "", "Only include cards with this label ID (Does not work with -a flag. Requires ID of label, not name)")
-		ListLabelIDs     = flag.Bool("labels", false, "Retrieve boards list of Label IDs")
-		Loud             = flag.Bool("loud", false, "Enable more verbose output")
-		StoragePath      = flag.String("s", "", "Root Level path to store board information")
-		SeparateArchived = flag.Bool("split", false, "Separate archived cards into their own directory")
-		ver              = flag.Bool("v", false, "Version Check")
+		Archived         = flag.Bool("a", false, "")
+		BoardID          = flag.String("b", "", "")
+		ListTotalCards   = flag.Bool("count", false, "")
+		LabelID          = flag.String("l", "", "")
+		ListLabelIDs     = flag.Bool("labels", false, "")
+		Loud             = flag.Bool("loud", false, "")
+		StoragePath      = flag.String("s", "", "n")
+		SeparateArchived = flag.Bool("split", false, "")
+		ver              = flag.Bool("v", false, "")
 	)
 
 	// Handle -h help
@@ -72,7 +76,7 @@ func getCLIArgs() (config ARGS, boards []string) {
 		os.Exit(0)
 	}
 
-	// If no board ID is provided, check if stdin is piped
+	// Check if we need to use STDIN (Pipe) or -b for BoardIDs
 	boards, err := getBoardIDs(*BoardID, os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
@@ -80,13 +84,14 @@ func getCLIArgs() (config ARGS, boards []string) {
 		os.Exit(1)
 	}
 
-	// Check for required flag of Storage Path if not listing labels or card totals
+	// Check for required flag of Storage Path if not using -labels or -count
 	if !*ListLabelIDs && !*ListTotalCards && *StoragePath == "" {
 		fmt.Println("Error: No Storage Path provided. REQUIRED")
 		printHelp(version)
 		os.Exit(1)
 	}
 
+	// Searching on a specific Label will not allow search of archives, need to inform user
 	if *LabelID != "" && *Archived {
 		fmt.Println("Error: Cannot use -l flag with -a flag. Use -l without -a to filter by label ID")
 		printHelp(version)
@@ -96,7 +101,11 @@ func getCLIArgs() (config ARGS, boards []string) {
 	return config, boards
 }
 
-// getOSENV - Get Trello API Key from OS Environment
+/*
+getOSENV
+
+	Get Trello API Key from OS Environment
+*/
 func getOSENV() (config ENV) {
 
 	// Load vars in dotenv file if it exists (preferred method)
@@ -123,8 +132,10 @@ func getOSENV() (config ENV) {
 }
 
 /*
-getBoardIDs - Get Board IDs from CLI flag or stdin
-If the -b flag is used, it will return that ID.
+getBoardIDs
+
+	Get Board IDs from CLI flag or stdin
+	If the -b flag is used, it will return that ID.
 */
 func getBoardIDs(boardFlag string, stdin io.Reader) ([]string, error) {
 	fi, err := os.Stdin.Stat()
@@ -157,7 +168,11 @@ func getBoardIDs(boardFlag string, stdin io.Reader) ([]string, error) {
 	return ids, nil
 }
 
-// printHelp - prints help menu when -h is used on CLI
+/*
+printHelp
+
+	Prints help menu when -h is used on CLI
+*/
 func printHelp(version string) {
 	fmt.Printf("\ttrellgo v%s by srv1054 (github.com/srv1054/trellgo)\n", version)
 	fmt.Println()
@@ -183,7 +198,11 @@ func printHelp(version string) {
 	os.Exit(0)
 }
 
-// dirCreate - Create main directory if it doesn't exist
+/*
+dirCreate
+
+	Create a directory if it doesn't exist
+*/
 func dirCreate(storagePath string) {
 	// check if passed directory exists if not create it
 	if _, err := os.Stat(storagePath); os.IsNotExist(err) {
@@ -203,7 +222,11 @@ func dirCreate(storagePath string) {
 	}
 }
 
-// prettyPrintLabels - Print out the labels output in a pretty table
+/*
+prettyPrintLabels
+
+	Print out the labels output in a pretty table
+*/
 func prettyPrintLabels(labels []*trello.Label, markdown bool) bytes.Buffer {
 
 	var (
@@ -254,7 +277,12 @@ func prettyPrintLabels(labels []*trello.Label, markdown bool) bytes.Buffer {
 	return buf
 }
 
-// SanitizePath - Sanitize the path for file system before creating directories.  Returns sanitized string
+/*
+SanitizePath
+
+	Sanitize the path for file system before creating directories.
+	Returns sanitized string
+*/
 func SanitizePathName(name string) string {
 	// Define allowed characters (letters, numbers, underscores, dashes, and dots)
 	re := regexp.MustCompile(`[^a-zA-Z0-9 ._-]`)
@@ -279,7 +307,11 @@ func SanitizePathName(name string) string {
 	return sanitized
 }
 
-// downLoadFile - Download a remote file to the local drive for certain types of attachments, like board background images
+/*
+downLoadFile
+
+	Download a remote file to the local drive for certain types of attachments, like board background images
+*/
 func downLoadFile(fileURL string, localFilePath string) error {
 
 	var (
@@ -334,7 +366,11 @@ func downLoadFile(fileURL string, localFilePath string) error {
 	return nil
 }
 
-// downloadFileAuthHeader - download file from URL to local file system when trello requires API authentication, likfe files attached to cards (PDF, etc)
+/*
+downloadFileAuthHeader
+
+	Download file from URL to local file system when trello requires API authentication, likfe files attached to cards (PDF, etc)
+*/
 func downloadFileAuthHeader(fileURL string, localFilePath string, apiKey string, apiToken string) error {
 
 	if ListLoud {

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,31 @@
+package main
+
+import "fmt"
+
+/*
+logger
+	Deal with outputs, console, log files, -qq, -loud, etc
+	console - true to send to console
+	honorLoud - honor the global variable ListLoud (-loud cli parameter)
+	config - Send in our config struct
+*/
+func logger(message string, console bool, honorLoud bool, config Config) {
+
+	// should we send to console
+	if console {
+		// over-ride if -qq super quiet mode is set
+		if !config.ARGS.SuperQuiet {
+			if honorLoud {
+				if ListLoud {
+					fmt.Println(message)
+				}
+			} else {
+				fmt.Println(message)
+			}
+		}
+	}
+
+	// Spot here for file logging when we implement that
+	// If logging is enabled, send everything to logs regardless of parameters
+
+}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func main() {
 
-	version = "0.3.01"
+	version = "0.3.02"
 
 	// Load CLI arguments and OS ENV
 	// This also must handle stdin Pipe input

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	version = "0.2.02"
 
 	// Load CLI arguments and OS ENV
-	// This also must handle stin Pipe input
+	// This also must handle stdin Pipe input
 	config.ARGS, listOfBoards = getCLIArgs()
 	config.ENV = getOSENV()
 
@@ -52,7 +52,7 @@ func main() {
 			continue
 		}
 
-		/* Process Label List Request */
+		/* Process Label List Request (-labels) */
 		if config.ARGS.ListLabelIDs {
 
 			labels, err := board.GetLabels(trello.Defaults())
@@ -68,7 +68,7 @@ func main() {
 			continue
 		}
 
-		/* Process Card Counts Request */
+		/* Process Card Counts Request (-count) */
 		if config.ARGS.ListTotalCards {
 
 			totalCards, _ := board.GetCards(trello.Arguments{"filter": "all"})
@@ -98,7 +98,7 @@ func main() {
 			continue
 		}
 
-		/* Process board data */
+		/* Process board data (-b) or (stdin pipe) */
 		if !config.ARGS.ListLabelIDs && !config.ARGS.ListTotalCards {
 			fmt.Println()
 			fmt.Println("Processing Board Name:", board.Name)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func main() {
 
-	version = "0.2.02"
+	version = "0.3.00"
 
 	// Load CLI arguments and OS ENV
 	// This also must handle stdin Pipe input
@@ -37,7 +37,7 @@ func main() {
 
 	// Message this once outside the loop, rather than for each board on multiple board input
 	if config.ARGS.ListTotalCards {
-		fmt.Printf("\n\nLarge Boards will take a moment to retreive this data...\n\n")
+		logger("\n\nLarge Boards will take a moment to retreive this data...\n\n", true, false, config)
 	}
 
 	// Range through board IDs.  Came in via CLI args or stdin pipe
@@ -46,9 +46,7 @@ func main() {
 		// validate board ID by getting the board data
 		board, err := client.GetBoard(boardID, trello.Defaults())
 		if err != nil {
-			fmt.Println("Error: Unable to get board data for board ID", boardID)
-			fmt.Println(err)
-
+			logger("Error: Unable to get board data for board ID"+boardID+": "+err.Error(), true, false, config)
 			continue
 		}
 
@@ -57,8 +55,7 @@ func main() {
 
 			labels, err := board.GetLabels(trello.Defaults())
 			if err != nil {
-				fmt.Println("Error: Unable to get label data for board ID "+board.ID+" ("+board.Name+")", boardID)
-				fmt.Println(err)
+				logger("Error: Unable to get label data for board ID "+board.ID+" ("+board.Name+"): "+err.Error(), true, false, config)
 				continue
 			}
 
@@ -100,16 +97,20 @@ func main() {
 
 		/* Process board data (-b) or (stdin pipe) */
 		if !config.ARGS.ListLabelIDs && !config.ARGS.ListTotalCards {
-			fmt.Println()
-			fmt.Println("Processing Board Name:", board.Name)
+			if !config.ARGS.SuperQuiet {
+				fmt.Println()
+			}
+			logger("Processing Board Name: "+board.Name, true, false, config)
 			dumpABoard(config, board, client)
 
-			fmt.Println()
-			fmt.Println("Processing Complete")
+			if !config.ARGS.SuperQuiet {
+				fmt.Println()
+			}
+			logger("Processing Complete", true, false, config)
 		}
 	}
 
 	if !config.ARGS.ListLabelIDs && !config.ARGS.ListTotalCards {
-		fmt.Println("Your board backups are in the directory:", config.ARGS.StoragePath)
+		logger("Your board backups are in the directory:"+config.ARGS.StoragePath, true, false, config)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func main() {
 
-	version = "0.3.00"
+	version = "0.3.01"
 
 	// Load CLI arguments and OS ENV
 	// This also must handle stdin Pipe input

--- a/trello.go
+++ b/trello.go
@@ -142,7 +142,7 @@ func dumpABoard(config Config, board *trello.Board, client *trello.Client) {
 		}
 	}
 
-	if !ListLoud {
+	if !ListLoud && !config.ARGS.SuperQuiet {
 		fmt.Println() // blank line to make counter output cleaner
 	}
 
@@ -150,8 +150,11 @@ func dumpABoard(config Config, board *trello.Board, client *trello.Client) {
 	for x, card := range cards {
 
 		// if we are in non-verbose mode, show a card progress counter
+		// unless we are in -qq then STFU
 		if !ListLoud {
-			fmt.Printf("\rProcessing %3d/%3d", x+1, len(cards))
+			if !config.ARGS.SuperQuiet {
+				fmt.Printf("\rProcessing %3d/%3d", x+1, len(cards))
+			}
 		}
 
 		// find cards list name

--- a/trello.go
+++ b/trello.go
@@ -520,7 +520,7 @@ func dumpABoard(config Config, board *trello.Board, client *trello.Client) {
 
 	}
 
-	if !ListLoud {
+	if !ListLoud && !config.ARGS.SuperQuiet {
 		fmt.Println() // New line after running counter
 	}
 }


### PR DESCRIPTION
Work on issue #3 

added -qq to silence all console output

As part of doing this, created a new logging/console output method and changed all applicable fmt.prints to use it. Allows support to honor -loud, -qq flags, and leaves a place holder for starting a file logging setup in Issue https://github.com/srv1054/trellgo/issues/2

see `logger.go` for new stuff